### PR TITLE
Very fast UTF-8, using Bjoern Hoehrmann's DFA decoder...

### DIFF
--- a/mregexp.c
+++ b/mregexp.c
@@ -1,4 +1,4 @@
-/* 
+/*
  * Copyright (c) 2020 Fabian van Rissenbeck
 
 * Permission is hereby granted, free of charge, to any person obtaining a copy
@@ -34,65 +34,75 @@
 #define __SIZE_MAX__ 4294967296
 #endif
 
-static inline unsigned utf8_char_width(uint8_t c)
+static inline uint32_t utf8_char_width(uint8_t c)
 {
-	int a1 = !(128 & c) && 1;
-	int a2 = (128 & c) && (64 & c) && !(32 & c);
-	int a3 = (128 & c) && (64 & c) && (32 & c) && !(16 & c);
-	int a4 = (128 & c) && (64 & c) && (32 & c) && (16 & c) && !(8 & c);
-
-	return a1 * 1 + a2 * 2 + a3 * 3 + a4 * 4;
+	// "optimal" branchless implementation...
+	uint32_t ret = (c < 0x80);        // 1
+	ret |= ((c & 0xE0) == 0xC0) << 1; // 2
+	ret |= ((c & 0xF0) == 0xE0)*3;    // 3
+	ret |= ((c & 0xF8) == 0xF0) << 2; // 4
+	return ret;
 }
 
-// utf8 valid is extremly slow
-static inline bool utf8_valid(const char *s)
+// Copyright (c) 2008-2009 Bjoern Hoehrmann <bjoern@hoehrmann.de>
+// See http://bjoern.hoehrmann.de/utf-8/decoder/dfa/ for details.
+
+#define UTF8_ACCEPT 0
+#define UTF8_REJECT 1
+
+static const uint8_t utf8d[] = {
+	0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0, // 00..1f
+	0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0, // 20..3f
+	0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0, // 40..5f
+	0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0, // 60..7f
+	1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,9,9,9,9,9,9,9,9,9,9,9,9,9,9,9,9, // 80..9f
+	7,7,7,7,7,7,7,7,7,7,7,7,7,7,7,7,7,7,7,7,7,7,7,7,7,7,7,7,7,7,7,7, // a0..bf
+	8,8,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2, // c0..df
+	0xa,0x3,0x3,0x3,0x3,0x3,0x3,0x3,0x3,0x3,0x3,0x3,0x3,0x4,0x3,0x3, // e0..ef
+	0xb,0x6,0x6,0x6,0x5,0x8,0x8,0x8,0x8,0x8,0x8,0x8,0x8,0x8,0x8,0x8, // f0..ff
+	0x0,0x1,0x2,0x3,0x5,0x8,0x7,0x1,0x1,0x1,0x4,0x6,0x1,0x1,0x1,0x1, // s0..s0
+	1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,0,1,1,1,1,1,0,1,0,1,1,1,1,1,1, // s1..s2
+	1,2,1,1,1,1,1,2,1,2,1,1,1,1,1,1,1,1,1,1,1,1,1,2,1,1,1,1,1,1,1,1, // s3..s4
+	1,2,1,1,1,1,1,1,1,2,1,1,1,1,1,1,1,1,1,1,1,1,1,3,1,3,1,1,1,1,1,1, // s5..s6
+	1,3,1,1,1,1,1,3,1,3,1,1,1,1,1,1,1,3,1,1,1,1,1,1,1,1,1,1,1,1,1,1, // s7..s8
+};
+
+static inline uint32_t utf8_decode(uint32_t *state, uint32_t *codep,
+				   const uint32_t byte)
 {
-	const size_t len = strlen(s);
+	uint32_t type = utf8d[byte];
+	*codep = (*state != UTF8_ACCEPT) ? (byte & 0x3fu) | (*codep << 6) :
+				       (0xff >> type) & (byte);
 
-	for (size_t i = 0; i < len;) {
-		const unsigned width = utf8_char_width((uint8_t)s[i]);
-
-		if (width == 0) {
-			return false;
-		}
-
-		if (i + width > len) {
-			return false;
-		}
-
-		for (unsigned j = 1; j < width; ++j)
-			if ((s[i + j] & (128 + 64)) != 128) {
-				return false;
-			}
-
-		i += width;
-	}
-
-	return true;
+	*state = utf8d[256 + (*state << 4) + type];
+	return *state;
 }
 
-bool mregexp_check_utf8(const char *s)
+static bool utf8_count_codepoints(size_t *count, const uint8_t *s)
 {
-	return utf8_valid(s);
+	uint32_t state = UTF8_ACCEPT, codepoint;
+	for (*count = 0; *s; ++s)
+		*count += !utf8_decode(&state, &codepoint, *s);
+	return state == UTF8_ACCEPT; // NB! valid == true
 }
 
-static const int utf8_peek_mods[] = {0, 127, 31, 15, 7};
+// End - Copyright (c) 2008-2009 Bjoern Hoehrmann <bjoern@hoehrmann.de>
+
+bool mregexp_valid_utf8(const char *s)
+{
+	size_t count;
+	bool valid = utf8_count_codepoints(&count, (const uint8_t *)s);
+	return valid;
+}
+
 static inline uint32_t utf8_peek(const char *s)
 {
 	if (*s == 0)
 		return 0;
 
-	const unsigned width = utf8_char_width(s[0]);
-	size_t ret = 0;
-
-	ret = s[0] & utf8_peek_mods[width];
-
-	for (unsigned i = 1; i < width; ++i) {
-		ret <<= 6;
-		ret += s[i] & 63;
-	}
-
-	return ret;
+	uint32_t state = UTF8_ACCEPT, codepoint;
+	utf8_decode(&state, &codepoint, *(const uint8_t *)s);
+	return codepoint;
 }
 
 static inline const char *utf8_next(const char *s)
@@ -467,7 +477,7 @@ static inline size_t parse_digit(const char *s, const char **leftover)
 	return ret;
 }
 
-/* parse complex quantifier of format {m,n} 
+/* parse complex quantifier of format {m,n}
  * valid formats: {,} {m,} {,n} {m} {m,n} */
 static void parse_complex_quant(const char *re, const char **leftover,
 				size_t *min_p, size_t *max_p)
@@ -853,7 +863,7 @@ MRegexp *mregexp_compile(const char *re)
 		return NULL;
 	}
 
-	if (!utf8_valid(re)) {
+	if (!mregexp_valid_utf8(re)) {
 		CompileException.err = MREGEXP_INVALID_UTF8;
 		CompileException.s = NULL;
 		return NULL;

--- a/mregexp.c
+++ b/mregexp.c
@@ -34,19 +34,14 @@
 #define __SIZE_MAX__ 4294967296
 #endif
 
-static inline unsigned utf8_char_width(uint8_t u)
+static inline uint32_t utf8_char_width(uint8_t c)
 {
-	// https://github.com/skeeto/pdjson/blob/master/pdjson.c
-	// Condensed version of utf8_seq_length():
-	if (u < 0x80)
-		return 1;
-	if (0xC2 <= u && u <= 0xDF)
-		return 2;
-	if (0xE0 <= u && u <= 0xEF)
-		return 3;
-	if (0xF0 <= u && u <= 0xF4)
-		return 4;
-	return 0;
+	// "optimal" branchless implementation...
+	uint32_t ret = (c < 0x80);        // 1
+	ret |= ((c & 0xE0) == 0xC0) << 1; // 2
+	ret |= ((c & 0xF0) == 0xE0)*3;    // 3
+	ret |= ((c & 0xF8) == 0xF0) << 2; // 4
+	return ret;
 }
 
 // Copyright (c) 2008-2009 Bjoern Hoehrmann <bjoern@hoehrmann.de>

--- a/mregexp.c
+++ b/mregexp.c
@@ -34,11 +34,10 @@
 #define __SIZE_MAX__ 4294967296
 #endif
 
-// https://github.com/skeeto/pdjson/blob/master/pdjson.c
-// Condensed version of utf8_seq_length():
-
 static inline unsigned utf8_char_width(uint8_t u)
 {
+	// https://github.com/skeeto/pdjson/blob/master/pdjson.c
+	// Condensed version of utf8_seq_length():
 	if (u < 0x80)
 		return 1;
 	if (0xC2 <= u && u <= 0xDF)
@@ -84,12 +83,12 @@ static inline uint32_t utf8_decode(uint32_t *state, uint32_t *codep,
 	return *state;
 }
 
-bool utf8_count_codepoints(size_t *count, const uint8_t *s)
+static bool utf8_count_codepoints(size_t *count, const uint8_t *s)
 {
 	uint32_t state = UTF8_ACCEPT, codepoint;
 	for (*count = 0; *s; ++s)
 		*count += !utf8_decode(&state, &codepoint, *s);
-	return state == UTF8_ACCEPT; // NB! true for valid
+	return state == UTF8_ACCEPT; // NB! valid == true
 }
 
 // End - Copyright (c) 2008-2009 Bjoern Hoehrmann <bjoern@hoehrmann.de>

--- a/mregexp.c
+++ b/mregexp.c
@@ -1,4 +1,4 @@
-/* 
+/*
  * Copyright (c) 2020 Fabian van Rissenbeck
 
 * Permission is hereby granted, free of charge, to any person obtaining a copy
@@ -34,65 +34,81 @@
 #define __SIZE_MAX__ 4294967296
 #endif
 
-static inline unsigned utf8_char_width(uint8_t c)
-{
-	int a1 = !(128 & c) && 1;
-	int a2 = (128 & c) && (64 & c) && !(32 & c);
-	int a3 = (128 & c) && (64 & c) && (32 & c) && !(16 & c);
-	int a4 = (128 & c) && (64 & c) && (32 & c) && (16 & c) && !(8 & c);
+// https://github.com/skeeto/pdjson/blob/master/pdjson.c
+// Condensed version of utf8_seq_length():
 
-	return a1 * 1 + a2 * 2 + a3 * 3 + a4 * 4;
+static inline unsigned utf8_char_width(uint8_t u)
+{
+	if (u < 0x80)
+		return 1;
+	if (0xC2 <= u && u <= 0xDF)
+		return 2;
+	if (0xE0 <= u && u <= 0xEF)
+		return 3;
+	if (0xF0 <= u && u <= 0xF4)
+		return 4;
+	return 0;
 }
 
-// utf8 valid is extremly slow
-static inline bool utf8_valid(const char *s)
+// Copyright (c) 2008-2009 Bjoern Hoehrmann <bjoern@hoehrmann.de>
+// See http://bjoern.hoehrmann.de/utf-8/decoder/dfa/ for details.
+
+#define UTF8_ACCEPT 0
+#define UTF8_REJECT 1
+
+static const uint8_t utf8d[] = {
+	0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0, // 00..1f
+	0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0, // 20..3f
+	0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0, // 40..5f
+	0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0, // 60..7f
+	1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,9,9,9,9,9,9,9,9,9,9,9,9,9,9,9,9, // 80..9f
+	7,7,7,7,7,7,7,7,7,7,7,7,7,7,7,7,7,7,7,7,7,7,7,7,7,7,7,7,7,7,7,7, // a0..bf
+	8,8,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2, // c0..df
+	0xa,0x3,0x3,0x3,0x3,0x3,0x3,0x3,0x3,0x3,0x3,0x3,0x3,0x4,0x3,0x3, // e0..ef
+	0xb,0x6,0x6,0x6,0x5,0x8,0x8,0x8,0x8,0x8,0x8,0x8,0x8,0x8,0x8,0x8, // f0..ff
+	0x0,0x1,0x2,0x3,0x5,0x8,0x7,0x1,0x1,0x1,0x4,0x6,0x1,0x1,0x1,0x1, // s0..s0
+	1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,0,1,1,1,1,1,0,1,0,1,1,1,1,1,1, // s1..s2
+	1,2,1,1,1,1,1,2,1,2,1,1,1,1,1,1,1,1,1,1,1,1,1,2,1,1,1,1,1,1,1,1, // s3..s4
+	1,2,1,1,1,1,1,1,1,2,1,1,1,1,1,1,1,1,1,1,1,1,1,3,1,3,1,1,1,1,1,1, // s5..s6
+	1,3,1,1,1,1,1,3,1,3,1,1,1,1,1,1,1,3,1,1,1,1,1,1,1,1,1,1,1,1,1,1, // s7..s8
+};
+
+static inline uint32_t utf8_decode(uint32_t *state, uint32_t *codep,
+				   const uint32_t byte)
 {
-	const size_t len = strlen(s);
+	uint32_t type = utf8d[byte];
+	*codep = (*state != UTF8_ACCEPT) ? (byte & 0x3fu) | (*codep << 6) :
+				       (0xff >> type) & (byte);
 
-	for (size_t i = 0; i < len;) {
-		const unsigned width = utf8_char_width((uint8_t)s[i]);
-
-		if (width == 0) {
-			return false;
-		}
-
-		if (i + width > len) {
-			return false;
-		}
-
-		for (unsigned j = 1; j < width; ++j)
-			if ((s[i + j] & (128 + 64)) != 128) {
-				return false;
-			}
-
-		i += width;
-	}
-
-	return true;
+	*state = utf8d[256 + (*state << 4) + type];
+	return *state;
 }
 
-bool mregexp_check_utf8(const char *s)
+bool utf8_count_codepoints(size_t *count, const uint8_t *s)
 {
-	return utf8_valid(s);
+	uint32_t state = UTF8_ACCEPT, codepoint;
+	for (*count = 0; *s; ++s)
+		*count += !utf8_decode(&state, &codepoint, *s);
+	return state == UTF8_ACCEPT; // NB! true for valid
 }
 
-static const int utf8_peek_mods[] = {0, 127, 31, 15, 7};
+// End - Copyright (c) 2008-2009 Bjoern Hoehrmann <bjoern@hoehrmann.de>
+
+bool mregexp_valid_utf8(const char *s)
+{
+	size_t count;
+	bool valid = utf8_count_codepoints(&count, (const uint8_t *)s);
+	return valid;
+}
+
 static inline uint32_t utf8_peek(const char *s)
 {
 	if (*s == 0)
 		return 0;
 
-	const unsigned width = utf8_char_width(s[0]);
-	size_t ret = 0;
-
-	ret = s[0] & utf8_peek_mods[width];
-
-	for (unsigned i = 1; i < width; ++i) {
-		ret <<= 6;
-		ret += s[i] & 63;
-	}
-
-	return ret;
+	uint32_t state = UTF8_ACCEPT, codepoint;
+	utf8_decode(&state, &codepoint, *(const uint8_t *)s);
+	return codepoint;
 }
 
 static inline const char *utf8_next(const char *s)
@@ -467,7 +483,7 @@ static inline size_t parse_digit(const char *s, const char **leftover)
 	return ret;
 }
 
-/* parse complex quantifier of format {m,n} 
+/* parse complex quantifier of format {m,n}
  * valid formats: {,} {m,} {,n} {m} {m,n} */
 static void parse_complex_quant(const char *re, const char **leftover,
 				size_t *min_p, size_t *max_p)
@@ -853,7 +869,7 @@ MRegexp *mregexp_compile(const char *re)
 		return NULL;
 	}
 
-	if (!utf8_valid(re)) {
+	if (!mregexp_valid_utf8(re)) {
 		CompileException.err = MREGEXP_INVALID_UTF8;
 		CompileException.s = NULL;
 		return NULL;


### PR DESCRIPTION
…and optimized uf8_char_width() by skeeto.

Note that utf8_peek() now uses the DFA decoder, and gives different result on two values from previous implementation:
Old output: e4 and f6, new output: 3 and 3. Otherwise same output when run through test suite. Still all tests passes, and sandbox.c works well.

Note also that `mregexp_valid_utf8()`  had no implementation (was implemented as `mregexp_check_utf8()` by mistake).